### PR TITLE
Remove component version selector from templates

### DIFF
--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -2,7 +2,6 @@
   <aside class="nav">
     <div class="panels">
 {{> nav-menu}}
-{{> nav-explore}}
     </div>
   </aside>
 </div>


### PR DESCRIPTION
We have only one component, and it's not versioned, so the component-version selector only adds noise.